### PR TITLE
Respond to SecondaryView size changes

### DIFF
--- a/ExpandableView/ExpandableView.cs
+++ b/ExpandableView/ExpandableView.cs
@@ -266,12 +266,16 @@ namespace Expandable
 
         private void OnSecondaryViewSizeChanged(object sender, EventArgs e)
         {
-            if (SecondaryView.Height <= 0) return;
+            if (SecondaryView.Height <= 0 || SizeChangeIsInsignificant()) return;
             SecondaryView.SizeChanged -= OnSecondaryViewSizeChanged;
             SecondaryView.HeightRequest = 0;
+            _startHeight = _lastVisibleHeight;
             _endHeight = SecondaryView.Height;
+            _lastVisibleHeight = SecondaryView.Height;
             InvokeAnimation();
         }
+
+        private bool SizeChangeIsInsignificant() => Math.Abs(SecondaryView.Height - _lastVisibleHeight) < 0.01;
 
         private void InvokeAnimation()
         {
@@ -287,7 +291,7 @@ namespace Expandable
 
             var length = ExpandAnimationLength;
             var easing = ExpandAnimationEasing;
-            if(!IsExpanded)
+            if(_endHeight < _startHeight)
             {
                 length = CollapseAnimationLength;
                 easing = CollapseAnimationEasing;
@@ -307,6 +311,7 @@ namespace Expandable
                         return;
                     }
                     RaiseStatusChanged(ExpandStatus.Expanded);
+                    SecondaryView.SizeChanged += OnSecondaryViewSizeChanged;
                 });
         }
 

--- a/ExpandableViewSample/ManyViewsPage.cs
+++ b/ExpandableViewSample/ManyViewsPage.cs
@@ -24,6 +24,17 @@ namespace ExpandableViewSample
 
         private View CreateExpandable(int number)
         {
+            var second = new Label
+            {
+                VerticalTextAlignment = TextAlignment.Center,
+                HorizontalTextAlignment = TextAlignment.Center,
+                FontAttributes = FontAttributes.Italic,
+                HeightRequest = 40,
+                BackgroundColor = Color.Black,
+                TextColor = Color.White,
+                Text = $"The Label of {number}"
+            };
+
             return new ExpandableView
             {
                 PrimaryView = new Label
@@ -43,39 +54,36 @@ namespace ExpandableViewSample
                     Spacing = 10,
                     Padding = new Thickness(20, 0),
                     Children = {
-                        new Label
+                        new Button
                         {
-                            VerticalTextAlignment = TextAlignment.Center,
-                            HorizontalTextAlignment = TextAlignment.Center,
+                            CornerRadius = 0,
                             FontAttributes = FontAttributes.Italic,
                             HeightRequest = 40,
                             BackgroundColor = Color.Black,
                             TextColor = Color.White,
-                            Text = $"The First of {number}"
+                            Text = $"Increase height of label",
+                            Command = new Command(() => ChangeHeight(second, 5))
                         },
-                        new Label
+                        second,
+                        new Button
                         {
-                            VerticalTextAlignment = TextAlignment.Center,
-                            HorizontalTextAlignment = TextAlignment.Center,
+                            CornerRadius = 0,
                             FontAttributes = FontAttributes.Italic,
                             HeightRequest = 40,
                             BackgroundColor = Color.Black,
                             TextColor = Color.White,
-                            Text = $"The Second {number}"
-                        },
-                        new Label
-                        {
-                            VerticalTextAlignment = TextAlignment.Center,
-                            HorizontalTextAlignment = TextAlignment.Center,
-                            FontAttributes = FontAttributes.Italic,
-                            HeightRequest = 40,
-                            BackgroundColor = Color.Black,
-                            TextColor = Color.White,
-                            Text = $"The Third {number}"
+                            Text = $"Decrease height of the label",
+                            Command = new Command(() => ChangeHeight(second, -5))
                         }
                     }
                 })
             };
+        }
+
+        private void ChangeHeight(Label target, double sizeChange)
+        {
+            target.HeightRequest += sizeChange;
+            ((StackLayout)target.Parent).HeightRequest = -1;
         }
     }
 }


### PR DESCRIPTION
Fixes #15 
Changes to SecondaryView.Height (for example, because child elements change their height) will grow or shrink the secondary view to the correct size